### PR TITLE
Update pwm_switch.c

### DIFF
--- a/pwm_switch.c
+++ b/pwm_switch.c
@@ -99,8 +99,8 @@ static void laser_settings_save (void)
 // Restore default settings and write to non volatile storage (NVS).
 static void laser_settings_restore (void)
 {
-    laser_pwm_settings.pwm_freq = 449;
-    laser_pwm_settings.pwm_max_value = 100;
+    laser_pwm_settings.pwm_freq = 1000;
+    laser_pwm_settings.pwm_max_value = 85;
     laser_pwm_settings.pwm_min_value = 0;
     laser_pwm_settings.pwm_off_value = 0;
     laser_pwm_settings.rpm_max = 255;


### PR DESCRIPTION
Realized default grbl sets laser PWM frequency to 1000Hz so updated plugin to match. 85% max output also seems to better match the LaserBeam requirements, may change back at a later date though if 100 seems to run without issue